### PR TITLE
Add Relationships_resizer.txt

### DIFF
--- a/Translation/en/Text/Relationships_resizer.txt
+++ b/Translation/en/Text/Relationships_resizer.txt
@@ -1,0 +1,3 @@
+#set level 5
+SimulationScene/CorrelationDiagram(Clone)/Canvas/MainPanel/CharaList/Window/BG/Content/CorrelationUI/SpeechBubble/Noise/Image/SVT-06-18=AutoResize(true, 12, 18)
+SimulationScene/CorrelationDiagram(Clone)/Canvas/MainPanel/CharaList/Window/BG/Content/CorrelationUI(Clone)/SpeechBubble/Noise/Image/SVT-06-18=AutoResize(true, 12, 18)


### PR DESCRIPTION
Added the _resizer.txt to the Relationships text. The font will auto resize and it will be able to fit up to 29 characters on the Text Bubbles. Any text longer than 29 characters in lenght will get cut off, and making the font size any lower than 12 is not ideal, the text will look really small.